### PR TITLE
Feature: Course Listing API

### DIFF
--- a/student_service/.github/PULL_REQUEST_TEMPLATE.md
+++ b/student_service/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+# 🚀 Pull Request: [Feature Title or Bug Fix]
+
+## 🔥 What’s Changing?
+Briefly explain:
+- What feature you built or what bug you fixed.
+- What part of the application it affects (e.g., "Courses", "Authentication Flow").
+
+## 🛠️ Why is it Needed?
+Explain the reasoning:
+- Requirement
+- Completing core [service] functionality
+- Improving documentation/testing/etc.
+
+## 🔬 How to Test This PR
+Describe how to test:
+- Steps to manually verify via Swagger UI or Postman.
+- Example requests or expected responses.
+
+## 📚 Documentation Updates
+- [ ] API endpoints documented in Swagger UI.
+- [ ] Migrations (if applicable) included and tested.
+- [ ] README updated (if applicable).
+
+## ✅ Checklist
+- [ ] Code is clean and readable.
+- [ ] Unit tests or integration tests written.
+- [ ] All tests pass locally (`mvn clean install` or `mvn test`).
+- [ ] No security issues introduced.

--- a/student_service/pom.xml
+++ b/student_service/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.5.0</version> <!-- Latest as of today -->
+			<version>2.5.0</version>
 		</dependency>
 	
 
@@ -105,7 +105,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-jackson</artifactId> <!-- or jjwt-gson, jjwt-orgjson -->
+			<artifactId>jjwt-jackson</artifactId>
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>

--- a/student_service/pom.xml
+++ b/student_service/pom.xml
@@ -84,6 +84,12 @@
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-database-postgresql</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version> <!-- Latest as of today -->
+		</dependency>
 	
 
 		<dependency>

--- a/student_service/src/main/java/dev/enkay/student_service/common/ApiResponse.java
+++ b/student_service/src/main/java/dev/enkay/student_service/common/ApiResponse.java
@@ -1,0 +1,17 @@
+package dev.enkay.student_service.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class ApiResponse<T> {
+  private boolean success;
+  private String message;
+  private T data;
+  private Instant timestamp;
+}

--- a/student_service/src/main/java/dev/enkay/student_service/config/OpenApiConfig.java
+++ b/student_service/src/main/java/dev/enkay/student_service/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package dev.enkay.student_service.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("Student Service API")
+            .version("v0.1.0")
+            .description(
+                "A simple service to manage student's courses, enrollments and graduations."));
+  }
+}

--- a/student_service/src/main/java/dev/enkay/student_service/config/SecurityConfig.java
+++ b/student_service/src/main/java/dev/enkay/student_service/config/SecurityConfig.java
@@ -31,29 +31,16 @@ public class SecurityConfig {
     return config.getAuthenticationManager();
   }
 
+
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-      http
-          .csrf(csrf -> csrf.disable())
-          .authorizeHttpRequests(auth -> auth
-              .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
-              .anyRequest().authenticated()
-          )
-          .formLogin(form -> form.disable())
-          .logout(logout -> logout.disable());
-
-      return http.build();
-  }
-
-  // @Bean
-  // public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-  //   http
-  //     .csrf(csrf -> csrf.disable())
-  //     .authorizeHttpRequests(auth -> auth
-  //       .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
-  //       .anyRequest().authenticated()
-  //     );
+    http
+      .csrf(csrf -> csrf.disable())
+      .authorizeHttpRequests(auth -> auth
+        .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+        .anyRequest().authenticated()
+      );
     
-  //   return http.build();
-  // }
+    return http.build();
+  }
 }

--- a/student_service/src/main/java/dev/enkay/student_service/config/SecurityConfig.java
+++ b/student_service/src/main/java/dev/enkay/student_service/config/SecurityConfig.java
@@ -15,6 +15,10 @@ public class SecurityConfig {
   private static final String[] PUBLIC_ENDPOINTS = {
     "/api/auth/**",
     "/api/courses/**",
+    "/swagger-ui/**",
+    "/swagger-ui.html",
+    "/v3/api-docs",
+    "/v3/api-docs/**",
   };
 
   @Bean
@@ -29,13 +33,27 @@ public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http
-      .csrf(csrf -> csrf.disable())
-      .authorizeHttpRequests(auth -> auth
-        .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
-        .anyRequest().authenticated()
-      );
-    
-    return http.build();
+      http
+          .csrf(csrf -> csrf.disable())
+          .authorizeHttpRequests(auth -> auth
+              .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+              .anyRequest().authenticated()
+          )
+          .formLogin(form -> form.disable())
+          .logout(logout -> logout.disable());
+
+      return http.build();
   }
+
+  // @Bean
+  // public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  //   http
+  //     .csrf(csrf -> csrf.disable())
+  //     .authorizeHttpRequests(auth -> auth
+  //       .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+  //       .anyRequest().authenticated()
+  //     );
+    
+  //   return http.build();
+  // }
 }

--- a/student_service/src/main/java/dev/enkay/student_service/config/SecurityConfig.java
+++ b/student_service/src/main/java/dev/enkay/student_service/config/SecurityConfig.java
@@ -13,7 +13,8 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
   private static final String[] PUBLIC_ENDPOINTS = {
-    "/api/auth/**"
+    "/api/auth/**",
+    "/api/courses/**",
   };
 
   @Bean

--- a/student_service/src/main/java/dev/enkay/student_service/controller/AuthController.java
+++ b/student_service/src/main/java/dev/enkay/student_service/controller/AuthController.java
@@ -4,6 +4,8 @@ import dev.enkay.student_service.dto.auth.LoginRequest;
 import dev.enkay.student_service.dto.auth.RegisterRequest;
 import dev.enkay.student_service.dto.auth.AuthResponse;
 import dev.enkay.student_service.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @Validated
 @RestController
 @RequestMapping("/api/auth")
+@Tag(name = "Authentication", description = "Endpoints for user registration and login")
 public class AuthController {
 
     private final AuthService authService;
@@ -22,11 +25,13 @@ public class AuthController {
         this.authService = authService;
     }
 
+    @Operation(summary = "Register a new user", description = "Creates a new portal user and registers them into the system.")
     @PostMapping("/register")
     public ResponseEntity<?> register(@RequestBody RegisterRequest request) {
         return ResponseEntity.ok(authService.register(request));
     }
 
+    @Operation(summary = "User Login", description = "Authenticates a user and returns a JWT token upon successful login.")
     @PostMapping("/login")
     public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request) {
         return ResponseEntity.ok(authService.login(request));

--- a/student_service/src/main/java/dev/enkay/student_service/controller/CourseController.java
+++ b/student_service/src/main/java/dev/enkay/student_service/controller/CourseController.java
@@ -1,0 +1,25 @@
+package dev.enkay.student_service.controller;
+
+import dev.enkay.student_service.dto.course.CourseResponseDto;
+import dev.enkay.student_service.service.CourseService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/courses")
+public class CourseController {
+
+  private final CourseService courseService;
+
+  public CourseController(CourseService courseService) {
+    this.courseService = courseService;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<CourseResponseDto>> getAllCourses() {
+    return ResponseEntity.ok(courseService.getAllCourses());
+  }
+}

--- a/student_service/src/main/java/dev/enkay/student_service/controller/CourseController.java
+++ b/student_service/src/main/java/dev/enkay/student_service/controller/CourseController.java
@@ -3,6 +3,9 @@ package dev.enkay.student_service.controller;
 import dev.enkay.student_service.common.ApiResponse;
 import dev.enkay.student_service.dto.course.CourseResponseDto;
 import dev.enkay.student_service.service.CourseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,6 +14,8 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/courses")
+@Tag(name = "Courses", description = "Endpoints for viewing available courses")
+
 public class CourseController {
 
   private final CourseService courseService;
@@ -19,6 +24,7 @@ public class CourseController {
     this.courseService = courseService;
   }
 
+  @Operation(summary = "Get all courses", description = "Fetches all MSc courses offered in the system.")
   @GetMapping
   public ResponseEntity<ApiResponse<List<CourseResponseDto>>> getAllCourses() {
     ApiResponse<List<CourseResponseDto>> response = ApiResponse.<List<CourseResponseDto>>builder()

--- a/student_service/src/main/java/dev/enkay/student_service/controller/CourseController.java
+++ b/student_service/src/main/java/dev/enkay/student_service/controller/CourseController.java
@@ -1,11 +1,12 @@
 package dev.enkay.student_service.controller;
 
+import dev.enkay.student_service.common.ApiResponse;
 import dev.enkay.student_service.dto.course.CourseResponseDto;
 import dev.enkay.student_service.service.CourseService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
 import java.util.List;
 
 @RestController
@@ -19,7 +20,14 @@ public class CourseController {
   }
 
   @GetMapping
-  public ResponseEntity<List<CourseResponseDto>> getAllCourses() {
-    return ResponseEntity.ok(courseService.getAllCourses());
+  public ResponseEntity<ApiResponse<List<CourseResponseDto>>> getAllCourses() {
+    ApiResponse<List<CourseResponseDto>> response = ApiResponse.<List<CourseResponseDto>>builder()
+    .success(true)
+    .message("Courses retrieved successfully")
+    .data(courseService.getAllCourses())
+    .timestamp(Instant.now())
+    .build();
+
+    return ResponseEntity.ok(response);
   }
 }

--- a/student_service/src/main/java/dev/enkay/student_service/dto/course/CourseResponseDto.java
+++ b/student_service/src/main/java/dev/enkay/student_service/dto/course/CourseResponseDto.java
@@ -1,0 +1,15 @@
+package dev.enkay.student_service.dto.course;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CourseResponseDto {
+    private Long id;
+    private String code;
+    private String title;
+    private String description;
+}

--- a/student_service/src/main/java/dev/enkay/student_service/entity/Course.java
+++ b/student_service/src/main/java/dev/enkay/student_service/entity/Course.java
@@ -1,0 +1,23 @@
+package dev.enkay.student_service.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "courses")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Course {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String code;
+
+  private String title;
+
+  private String description;
+}

--- a/student_service/src/main/java/dev/enkay/student_service/repository/CourseRepository.java
+++ b/student_service/src/main/java/dev/enkay/student_service/repository/CourseRepository.java
@@ -1,0 +1,9 @@
+package dev.enkay.student_service.repository;
+
+import dev.enkay.student_service.entity.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CourseRepository extends JpaRepository<Course, Long> {
+}

--- a/student_service/src/main/java/dev/enkay/student_service/service/CourseService.java
+++ b/student_service/src/main/java/dev/enkay/student_service/service/CourseService.java
@@ -1,0 +1,9 @@
+package dev.enkay.student_service.service;
+
+import dev.enkay.student_service.dto.course.CourseResponseDto;
+
+import java.util.List;
+
+public interface CourseService {
+  List<CourseResponseDto> getAllCourses();
+}

--- a/student_service/src/main/java/dev/enkay/student_service/service/impl/CourseServiceImpl.java
+++ b/student_service/src/main/java/dev/enkay/student_service/service/impl/CourseServiceImpl.java
@@ -1,0 +1,34 @@
+package dev.enkay.student_service.service.impl;
+
+import dev.enkay.student_service.dto.course.CourseResponseDto;
+import dev.enkay.student_service.entity.Course;
+import dev.enkay.student_service.repository.CourseRepository;
+import dev.enkay.student_service.service.CourseService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CourseServiceImpl implements CourseService {
+
+  private final CourseRepository courseRepository;
+
+  @Autowired
+  public CourseServiceImpl(CourseRepository courseRepository) {
+    this.courseRepository = courseRepository;
+  }
+
+  @Override
+  public List<CourseResponseDto> getAllCourses() {
+    return courseRepository.findAll()
+        .stream()
+        .map(course -> new CourseResponseDto(
+            course.getId(),
+            course.getCode(),
+            course.getTitle(),
+            course.getDescription()))
+        .collect(Collectors.toList());
+  }
+}

--- a/student_service/src/main/resources/db/migration/V2__create_courses_table.sql
+++ b/student_service/src/main/resources/db/migration/V2__create_courses_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE courses (
+  id BIGSERIAL PRIMARY KEY,
+  code VARCHAR(20) NOT NULL UNIQUE,
+  title VARCHAR(255) NOT NULL,
+  description TEXT
+);

--- a/student_service/src/main/resources/db/migration/V3__seed_courses_table.sql
+++ b/student_service/src/main/resources/db/migration/V3__seed_courses_table.sql
@@ -1,0 +1,31 @@
+INSERT INTO courses (code, title, description)
+VALUES (
+    'CSC701',
+    'Advanced Artificial Intelligence',
+    'Explores machine learning, deep learning, and AI system design for real-world applications.'
+  ),
+  (
+    'CSC702',
+    'Distributed Systems',
+    'Covers architectures, algorithms, and performance issues in distributed computing.'
+  ),
+  (
+    'CSC703',
+    'Cloud Computing and Virtualization',
+    'Focus on scalable cloud infrastructure, virtualization, and cloud-native application design.'
+  ),
+  (
+    'CSC704',
+    'Cybersecurity and Risk Management',
+    'Advanced techniques for securing systems, managing risk, and responding to cyber threats.'
+  ),
+  (
+    'CSC705',
+    'Big Data Analytics',
+    'Analyzing large datasets using modern frameworks like Hadoop, Spark, and machine learning.'
+  ),
+  (
+    'CSC706',
+    'Research Methods in Computer Science',
+    'Covers methodologies and best practices for conducting academic and industrial research projects.'
+  );

--- a/student_service/src/test/java/dev/enkay/student_service/controller/CourseControllerTest.java
+++ b/student_service/src/test/java/dev/enkay/student_service/controller/CourseControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.Arrays;
 import java.util.List;
@@ -22,7 +23,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(CourseController.class)
-@Import(SecurityConfig.class) // Import your SecurityConfig
+@Import(SecurityConfig.class)
 class CourseControllerTest {
 
   @Autowired
@@ -37,30 +38,31 @@ class CourseControllerTest {
   @Test
   void shouldReturnListOfCoursesSuccessfully() throws Exception {
     // Arrange
-    CourseResponseDto course1 = new CourseResponseDto(1L, "CSC701", "Advanced AI",
-        "Deep learning, ML, real-world AI systems");
-    CourseResponseDto course2 = new CourseResponseDto(2L, "CSC702", "Distributed Systems",
-        "Architectures and performance");
+    CourseResponseDto course1 = new CourseResponseDto(1L, "CSC701", "Advanced AI", "Deep learning, ML, real-world AI systems");
+    CourseResponseDto course2 = new CourseResponseDto(2L, "CSC702", "Distributed Systems", "Architectures and performance");
 
     List<CourseResponseDto> courses = Arrays.asList(course1, course2);
 
     when(courseService.getAllCourses()).thenReturn(courses);
 
-    // Act + Assert
-    mockMvc.perform(get("/api/courses")
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.success").value(true))
-        .andExpect(jsonPath("$.message").value("Courses retrieved successfully"))
-        .andExpect(jsonPath("$.data.length()").value(2))
-        .andExpect(jsonPath("$.data[0].id").value(1))
-        .andExpect(jsonPath("$.data[0].code").value("CSC701"))
-        .andExpect(jsonPath("$.data[0].title").value("Advanced AI"))
-        .andExpect(jsonPath("$.data[0].description").value("Deep learning, ML, real-world AI systems"))
-        .andExpect(jsonPath("$.data[1].id").value(2))
-        .andExpect(jsonPath("$.data[1].code").value("CSC702"))
-        .andExpect(jsonPath("$.data[1].title").value("Distributed Systems"))
-        .andExpect(jsonPath("$.data[1].description").value("Architectures and performance"))
-        .andExpect(jsonPath("$.timestamp").exists());
+    // Act
+    ResultActions resultActions = mockMvc.perform(get("/api/courses")
+      .contentType(MediaType.APPLICATION_JSON));
+    
+    // Assert
+    resultActions.andExpect(status().isOk())
+    .andExpectAll(
+        jsonPath("$.success").value(true),
+        jsonPath("$.message").value("Courses retrieved successfully"),
+        jsonPath("$.data.length()").value(2),
+        jsonPath("$.data[0].id").value(1),
+        jsonPath("$.data[0].code").value("CSC701"),
+        jsonPath("$.data[0].title").value("Advanced AI"),
+        jsonPath("$.data[0].description").value("Deep learning, ML, real-world AI systems"),
+        jsonPath("$.data[1].id").value(2),
+        jsonPath("$.data[1].code").value("CSC702"),
+        jsonPath("$.data[1].title").value("Distributed Systems"),
+        jsonPath("$.data[1].description").value("Architectures and performance"),
+        jsonPath("$.timestamp").exists());
   }
 }

--- a/student_service/src/test/java/dev/enkay/student_service/controller/CourseControllerTest.java
+++ b/student_service/src/test/java/dev/enkay/student_service/controller/CourseControllerTest.java
@@ -1,0 +1,62 @@
+package dev.enkay.student_service.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dev.enkay.student_service.config.SecurityConfig;
+import dev.enkay.student_service.dto.course.CourseResponseDto;
+import dev.enkay.student_service.service.CourseService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(CourseController.class)
+@Import(SecurityConfig.class)
+class CourseControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private CourseService courseService;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  void shouldReturnListOfCoursesSuccessfully() throws Exception {
+    // Arrange
+    CourseResponseDto course1 = new CourseResponseDto(1L, "CSC701", "Advanced AI",
+        "Deep learning, ML, real-world AI systems");
+    CourseResponseDto course2 = new CourseResponseDto(2L, "CSC702", "Distributed Systems",
+        "Architectures and performance");
+
+    List<CourseResponseDto> courses = Arrays.asList(course1, course2);
+
+    when(courseService.getAllCourses()).thenReturn(courses);
+
+    // Act + Assert
+    mockMvc.perform(get("/api/courses")
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].id").value(1))
+        .andExpect(jsonPath("$[0].code").value("CSC701"))
+        .andExpect(jsonPath("$[0].title").value("Advanced AI"))
+        .andExpect(jsonPath("$[0].description").value("Deep learning, ML, real-world AI systems"))
+        .andExpect(jsonPath("$[1].id").value(2))
+        .andExpect(jsonPath("$[1].code").value("CSC702"))
+        .andExpect(jsonPath("$[1].title").value("Distributed Systems"))
+        .andExpect(jsonPath("$[1].description").value("Architectures and performance"));
+  }
+}

--- a/student_service/src/test/java/dev/enkay/student_service/controller/CourseControllerTest.java
+++ b/student_service/src/test/java/dev/enkay/student_service/controller/CourseControllerTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.enkay.student_service.config.SecurityConfig;
 import dev.enkay.student_service.dto.course.CourseResponseDto;
 import dev.enkay.student_service.service.CourseService;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -21,7 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(CourseController.class)
-@Import(SecurityConfig.class)
+@Import(SecurityConfig.class) // Import your SecurityConfig
 class CourseControllerTest {
 
   @Autowired
@@ -49,14 +50,17 @@ class CourseControllerTest {
     mockMvc.perform(get("/api/courses")
         .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.length()").value(2))
-        .andExpect(jsonPath("$[0].id").value(1))
-        .andExpect(jsonPath("$[0].code").value("CSC701"))
-        .andExpect(jsonPath("$[0].title").value("Advanced AI"))
-        .andExpect(jsonPath("$[0].description").value("Deep learning, ML, real-world AI systems"))
-        .andExpect(jsonPath("$[1].id").value(2))
-        .andExpect(jsonPath("$[1].code").value("CSC702"))
-        .andExpect(jsonPath("$[1].title").value("Distributed Systems"))
-        .andExpect(jsonPath("$[1].description").value("Architectures and performance"));
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.message").value("Courses retrieved successfully"))
+        .andExpect(jsonPath("$.data.length()").value(2))
+        .andExpect(jsonPath("$.data[0].id").value(1))
+        .andExpect(jsonPath("$.data[0].code").value("CSC701"))
+        .andExpect(jsonPath("$.data[0].title").value("Advanced AI"))
+        .andExpect(jsonPath("$.data[0].description").value("Deep learning, ML, real-world AI systems"))
+        .andExpect(jsonPath("$.data[1].id").value(2))
+        .andExpect(jsonPath("$.data[1].code").value("CSC702"))
+        .andExpect(jsonPath("$.data[1].title").value("Distributed Systems"))
+        .andExpect(jsonPath("$.data[1].description").value("Architectures and performance"))
+        .andExpect(jsonPath("$.timestamp").exists());
   }
 }

--- a/student_service/src/test/java/dev/enkay/student_service/service/CourseServiceTest.java
+++ b/student_service/src/test/java/dev/enkay/student_service/service/CourseServiceTest.java
@@ -1,0 +1,57 @@
+package dev.enkay.student_service.service;
+
+import dev.enkay.student_service.dto.course.CourseResponseDto;
+import dev.enkay.student_service.entity.Course;
+import dev.enkay.student_service.repository.CourseRepository;
+import dev.enkay.student_service.service.impl.CourseServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class CourseServiceTest {
+
+  @Mock
+  private CourseRepository courseRepository;
+
+  @InjectMocks
+  private CourseServiceImpl courseService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void shouldReturnAllCoursesSuccessfully() {
+    // Arrange
+    Course course1 = new Course(1L, "CSC701", "Advanced AI", "Deep learning, ML, real-world AI systems");
+    Course course2 = new Course(2L, "CSC702", "Distributed Systems", "Architectures and performance");
+
+    List<Course> courses = Arrays.asList(course1, course2);
+
+    when(courseRepository.findAll()).thenReturn(courses);
+
+    // Act
+    List<CourseResponseDto> result = courseService.getAllCourses();
+
+    // Assert
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getId()).isEqualTo(1L);
+    assertThat(result.get(0).getCode()).isEqualTo("CSC701");
+    assertThat(result.get(0).getTitle()).isEqualTo("Advanced AI");
+    assertThat(result.get(0).getDescription()).isEqualTo("Deep learning, ML, real-world AI systems");
+
+    assertThat(result.get(1).getId()).isEqualTo(2L);
+    assertThat(result.get(1).getCode()).isEqualTo("CSC702");
+    assertThat(result.get(1).getTitle()).isEqualTo("Distributed Systems");
+    assertThat(result.get(1).getDescription()).isEqualTo("Architectures and performance");
+  }
+}


### PR DESCRIPTION
# 🚀 Pull Request: Course Listing API

## 🔥 What’s Changing?
- Implemented the `/api/courses` endpoint to fetch all MSc courses.
- Integrated `ApiResponse<T>` to standardise response format.
- Added unit tests for CourseService and integration tests for CourseController.
- Documented the endpoint using Swagger annotations (`@Tag`, `@Operation`).

## 🛠️ Why is it Needed?
- Forms part of the core Student Service requirements.
- Allows users to view available MSc courses before enrolment.
- Completes the basic "View Courses" functionality.

## 🔬 How to Test This PR
- Pull branch locally
- Visit Swagger UI at `http://localhost:8080/swagger-ui.html`.
- Locate the **Courses** section.
- Call `GET /api/courses`.
- Expect a `200 OK` response with a list of predefined MSc course entries

Example response body structure:
```json
{
  "success": true,
  "message": "Courses retrieved successfully",
  "data": [
    {
      "id": 1,
      "code": "CSC701",
      "title": "Advanced AI",
      "description": "Deep learning, ML, real-world AI systems"
    },
    {
      "id": 2,
      "code": "CSC702",
      "title": "Distributed Systems",
      "description": "Architectures and performance"
    }
  ],
  "timestamp": "2025-04-27T10:00:00Z"
}
